### PR TITLE
Add github workflow file to begin migration from circleci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: "🚀 publish"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    name: 🚀 publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📚 checkout
+        uses: actions/checkout@v2.1.1
+      - name: 🟢 node
+        uses: actions/setup-node@v1.4.2
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org
+      - name: 🧪 test
+        run: yarn test
+      - name: 🚀 publish
+        run: yarn deploy
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}


### PR DESCRIPTION
CircleCI config is now invalid after 4 years of no update. Using the opportunity to switch over to github actions